### PR TITLE
Add docker-compose development configuration

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:7.10-slim
+
+RUN mkdir -p /lastbin
+
+ADD package.lua /lastbin
+
+RUN npm install -g nodemon@1.11.0 && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y libsqlite3-dev && \
+    curl -L https://github.com/luvit/lit/raw/master/get-lit.sh --silent | sh && \
+    cd /lastbin && \
+    /lit install && \
+    rm -rf /var/lib/apt/lists /lit /luvi
+
+WORKDIR /lastbin
+
+CMD ["nodemon", "--exec", "/luvit", "--ext", "lua", "server.lua"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+
+  lastbin:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: lastbin-dev
+    volumes:
+      - ./server.lua:/lastbin/server.lua:ro
+      - ./tmpl:/lastbin/tmpl:ro
+      - ./www:/lastbin/www:ro
+      - ./libs/mimes.lua:/lastbin/libs/mimes.lua:ro
+      - ./libs/template.lua:/lastbin/libs/template.lua:ro
+    ports:
+      - "42424:42424"


### PR DESCRIPTION
- Installation and setup is fully automated, run `docker-compose -f docker-compose.dev.yml up`
  and it works, whatever OS your system might have

- Source files are mounted into the container with clean read-only
  volumes, any change on the host is immedialty reflected

- The container port is bound to the host, the service is still
  accessible from http://localhost:42424/ on the host

- And the last, but not the least: Nodemon restarts magically the
  server when a Lua file is changed :tada: 